### PR TITLE
Adds an EnvStrategy to pull from ENV

### DIFF
--- a/lib/flip.rb
+++ b/lib/flip.rb
@@ -15,6 +15,7 @@
   declarable
   declaration_strategy
   definition
+  env_strategy
   facade
   feature_set
   forbidden

--- a/lib/flip/env_strategy.rb
+++ b/lib/flip/env_strategy.rb
@@ -1,0 +1,30 @@
+module Flip
+  class EnvStrategy < AbstractStrategy
+    def description
+      "Environment-variable backed; applies to all users"
+    end
+
+    def knows? definition
+      env.key? env_var_name(definition)
+    end
+
+    def on? definition
+      env[env_var_name(definition)] === 'true'
+    end
+
+    def switchable?
+      false
+    end
+
+    private
+
+    def env
+      ENV || {}
+    end
+
+    def env_var_name definition
+      definition = definition.key unless definition.is_a? Symbol
+      "flip_#{definition}"
+    end
+  end
+end

--- a/spec/env_strategy_spec.rb
+++ b/spec/env_strategy_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+
+describe Flip::EnvStrategy do
+  let(:environment) { { "flip_one" => "true", "flip_two" => "false" } }
+  let(:strategy) do
+    Flip::EnvStrategy.new.tap do |s|
+      s.stub(:env) { environment }
+    end
+  end
+
+  its(:description) { should be_present }
+  it { should_not be_switchable }
+
+  context "enabled feature" do
+    specify "#knows? is true" do
+      strategy.knows?(:one).should be_true
+    end
+
+    specify "#on? is true" do
+      strategy.on?(:one).should be_true
+    end
+  end
+
+  context "disabled feature" do
+    specify "#knows? is true" do
+      strategy.knows?(:two).should be_true
+    end
+
+    specify "#on? is false" do
+      strategy.on?(:two).should be_false
+    end
+  end
+
+  context "feature unknown to strategy" do
+    specify "#knows? is false" do
+      strategy.knows?(:three).should be_false
+    end
+
+    specify "#on? is false" do
+      strategy.on?(:three).should be_false
+    end
+  end
+end
+


### PR DESCRIPTION
Looks for feature flag specifications in environment.  This is useful for applications deployed, for example, to Heroku, where environment-variable configuration is common, and provides a lower-overhead method of system-wide feature flag configuration.

These variables are not settable from Flip's UI, however.
